### PR TITLE
Fix the TypeScript type for the return value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,10 +28,10 @@ declare const macosRelease: {
 	//=> {name: 'Big Sur', version: '11'}
 	```
 	*/
-	(release?: string): string;
+	(release?: string): {name: string, version: string};
 
 	// TODO: remove this in the next major version, refactor the whole definition to:
-	// declare function macosRelease(release?: string): string;
+	// declare function macosRelease(release?: string): {name: string, version: string};
 	// export = macosRelease;
 	default: typeof macosRelease;
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
 import macosRelease = require('.');
 
-expectType<string>(macosRelease());
-expectType<string>(macosRelease('foo'));
+expectType<{name: string, version: string}>(macosRelease());
+expectType<{name: string, version: string}>(macosRelease('foo'));


### PR DESCRIPTION
Thanks for this handy library.

I'm using it from Typescript and noticed the return type doesn't match up. This change makes the return type `{name: string, version: string}` instead of `string`.

The workaround for now is to cast to the correct type:

```typescript
import macosRelease from 'macos-release';
const {name, version} = macosRelease() as unknown as {name: string, version: string};
```