### PR TITLE
fix: don't throw when OS is unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const os = require('os');
 
 const nameMap = new Map([
+	[22, ['Ventura', '13']],
 	[21, ['Monterey', '12']],
 	[20, ['Big Sur', '11']],
 	[19, ['Catalina', '10.15']],
@@ -24,7 +25,7 @@ const nameMap = new Map([
 const macosRelease = release => {
 	release = Number((release || os.release()).split('.')[0]);
 
-	const [name, version] = nameMap.get(release);
+	const [name, version] = nameMap.get(release) || ['Unknown', ''];
 
 	return {
 		name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "macos-release",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "Get the name and version of a macOS release from the Darwin version",
 	"license": "MIT",
 	"repository": "sindresorhus/macos-release",

--- a/test.js
+++ b/test.js
@@ -12,3 +12,10 @@ test('main', t => {
 		version: '11'
 	});
 });
+
+test('unknown version', t => {
+	t.deepEqual(macosRelease('4.0.0'), {
+		name: 'Unknown',
+		version: ''
+	});
+});


### PR DESCRIPTION
**What:**
Update 2.5.x of macos-release to not throw. Instead return an unknown name and empty version string.

**Why:**
I've recently worked on a legacy repo that no longer builds because macos-release is throwing but the library pulling it in does not account for this. It is not easily fixed due to limited control within the main app, the age of the tooling, and limited resources.

With this change legacy apps still being maintained may at some point log "unknown" for the mac version, but they won't crash.

Using something like npm overrides and macos-release 3.x is not an option because it uses ESM without a CommonJS export and the library pulling in macos-release is not the main app but in node_modules where I have no control.

Installing a local forked tar.gz is not an option because npm does not consistently use it. Ffor example npm revers packages to using macos-release 2.5.0 when linking. I believe this is an npm bug.

**Notes:**
I'm not sure how to properly do this PR since there is no branch pointing to v2.5.0. I've pushed a 2.5.1 tag but I don't see a way to PR stand alone commits. 