### PR TITLE
fix: provide a CJS version as well

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,4 +1,4 @@
-import os from 'node:os';
+const os = require('os');
 
 const nameMap = new Map([
 	[22, ['Ventura', '13']],
@@ -21,7 +21,7 @@ const nameMap = new Map([
 	[5, ['Puma', '10.1']],
 ]);
 
-export default function macosRelease(release) {
+function macosRelease(release) {
 	release = Number((release || os.release()).split('.')[0]);
 
 	const [name, version] = nameMap.get(release) || ['Unknown', ''];
@@ -31,3 +31,5 @@ export default function macosRelease(release) {
 		version,
 	};
 }
+
+module.exports = macosRelease;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+import os from 'node:os';
+
+const nameMap = new Map([
+	[22, ['Ventura', '13']],
+	[21, ['Monterey', '12']],
+	[20, ['Big Sur', '11']],
+	[19, ['Catalina', '10.15']],
+	[18, ['Mojave', '10.14']],
+	[17, ['High Sierra', '10.13']],
+	[16, ['Sierra', '10.12']],
+	[15, ['El Capitan', '10.11']],
+	[14, ['Yosemite', '10.10']],
+	[13, ['Mavericks', '10.9']],
+	[12, ['Mountain Lion', '10.8']],
+	[11, ['Lion', '10.7']],
+	[10, ['Snow Leopard', '10.6']],
+	[9, ['Leopard', '10.5']],
+	[8, ['Tiger', '10.4']],
+	[7, ['Panther', '10.3']],
+	[6, ['Jaguar', '10.2']],
+	[5, ['Puma', '10.1']],
+]);
+
+export default function macosRelease(release) {
+	release = Number((release || os.release()).split('.')[0]);
+
+	const [name, version] = nameMap.get(release) || ['Unknown', ''];
+	return {
+		name,
+		version,
+	};
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	},
 	"type": "module",
 	"exports": "./index.js",
+	"main": "./index.cjs",
 	"engines": {
 		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
@@ -20,6 +21,7 @@
 	},
 	"files": [
 		"index.js",
+		"index.cjs",
 		"index.d.ts"
 	],
 	"keywords": [


### PR DESCRIPTION
In older versions of node, if we want to use this package, it has `"type": "module"` in package.json
and it doesn't support `cjs` at all. Sooo this is a requirement ppl