### PR TITLE
fix: don't throw when OS is unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const os = require('os');
 
 const nameMap = new Map([
+	[22, ['Ventura', '13']],
 	[21, ['Monterey', '12']],
 	[20, ['Big Sur', '11']],
 	[19, ['Catalina', '10.15']],
@@ -24,7 +25,7 @@ const nameMap = new Map([
 const macosRelease = release => {
 	release = Number((release || os.release()).split('.')[0]);
 
-	const [name, version] = nameMap.get(release);
+	const [name, version] = nameMap.get(release) || ['Unknown', ''];
 
 	return {
 		name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "macos-release",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "Get the name and version of a macOS release from the Darwin version",
 	"license": "MIT",
 	"repository": "sindresorhus/macos-release",

--- a/test.js
+++ b/test.js
@@ -12,3 +12,10 @@ test('main', t => {
 		version: '11'
 	});
 });
+
+test('unknown version', t => {
+	t.deepEqual(macosRelease('4.0.0'), {
+		name: 'Unknown',
+		version: ''
+	});
+});


### PR DESCRIPTION
**What:**
Don't throw when an unknown release is passed in.

**Why:**
Legacy apps are crashing due to transient dependencies not handling the exception.