### PR TITLE
Fix darwin kernel version mapping for macOS 27

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import os from 'node:os';
 
 const nameMap = new Map([
-	[26, ['Golden Gate', '27']],
+	[27, ['Golden Gate', '27']],
 	[25, ['Tahoe', '26']],
 	[24, ['Sequoia', '15']],
 	[23, ['Sonoma', '14']],


### PR DESCRIPTION
@sindresorhus I'm so sorry. Looks like Apple for the first time in years bumped kernel version by two to match it's brand name. I wrongfully checked build name, assuming it must follow the same pattern (which still starts with 26).